### PR TITLE
Move Cloudflare Workers instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,10 @@ To start the local site use:
 To deploy updated versions:
 `npm run deploy`
 
+# Using Cloudflare Workers
 
+1. Run `npx wrangler dev src/index.js` in your terminal to start a development server
+1. Open a browser tab at http://localhost:8080/ to see your worker in action
+1. Run `npx wrangler publish src/index.js --name my-worker` to publish your worker
 
-
-
+Learn more at https://developers.cloudflare.com/workers/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ To deploy updated versions:
 
 # Using Cloudflare Workers
 
-1. Run `npx wrangler dev src/index.js` in your terminal to start a development server
+1. Run `npx wrangler dev <filepath>` in your terminal to start a development server
 1. Open a browser tab at http://localhost:8080/ to see your worker in action
-1. Run `npx wrangler publish src/index.js --name my-worker` to publish your worker
+1. Run `npx wrangler publish <file-path> --name <worker-name>` to publish your worker
 
 Learn more at https://developers.cloudflare.com/workers/

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,12 +1,3 @@
-/**
- * Welcome to Cloudflare Workers! This is your first worker.
- *
- * - Run `npx wrangler dev src/index.js` in your terminal to start a development server
- * - Open a browser tab at http://localhost:8080/ to see your worker in action
- * - Run `npx wrangler publish src/index.js --name my-worker` to publish your worker
- *
- * Learn more at https://developers.cloudflare.com/workers/
- */
 import { onRequestPost } from "./functions/on-req-post";
 import { StatusCodes } from "http-status-codes";
 


### PR DESCRIPTION
Addresses issue #12 
Re-located the Cloudflare Workers instructions from the top of `worker/index.js` to `CONTRIBUTING.md`. 